### PR TITLE
Updating requirements of README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,12 @@ Don't want to run Drupal Check on your own? We offer a hosted version in [Centar
 ## Requirements
 
 * PHP >=7.1
+* composer/xdebug-handler >=1.3
+* jean85/pretty-package-versions >=1.2
+* mglaman/phpstan-drupal-deprecations >=0.11.1
+* mglaman/phpstan-junit >=0.11.1
+* symfony/console >=4.2
+* webflo/drupal-finder >=1
 
 ## Installation
 


### PR DESCRIPTION

### Observed result

Current [readme](https://github.com/mglaman/drupal-check#requirements) states : 
`PHP >=7.1`

However, composer.json defines more [requirements](https://github.com/mglaman/drupal-check/blob/master/composer.json#L12) : 
```
    "require": {
        "php": "~7.1",
        "composer/xdebug-handler": "^1.3",
        "jean85/pretty-package-versions": "^1.2",
        "mglaman/phpstan-drupal-deprecations": "^0.11.1",
        "mglaman/phpstan-junit": "^0.11.1",
        "symfony/console": "^4.2",
        "webflo/drupal-finder": "^1.1"
```



### Expected result

It would make sense to update readme to make dependencies more exaustive

See https://github.com/mglaman/drupal-check/issues/38#issuecomment-484885343


### Todo

Update REAME.md with all required packages and their versions

This PR does not solve the rest of the issue discussed in https://github.com/mglaman/drupal-check/issues/38


