### PR TITLE
Add support for checking multiple paths (implements #63)

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -95,6 +95,10 @@ jobs:
           name: Phar - Run against a module
           command: |
             php drupal-check.phar /tmp/drupal/core/modules/dynamic_page_cache -vvv
+      - run:
+          name: Phar - Run against multiple paths
+          command: |
+            php drupal-check.phar /tmp/drupal/core/install.php /tmp/drupal/core/modules/dynamic_page_cache -vvv
       - global-require
       - run:
           name: Global - Run against a file

--- a/README.md
+++ b/README.md
@@ -56,13 +56,13 @@ cd drupal
 Usage:
 
   ```
-  drupal-check [OPTIONS] [DIR]
+  drupal-check [OPTIONS] [DIRS]
   ```
 
 Arguments:
 
 * `OPTIONS` - See "Options" for allowed values. Specify multiples in sequence, e.g. `-ad`.
-* `DIR` - Can be any directory within the root of a Drupal project.
+* `DIRS` - One or more directories within the root of a Drupal project.
 
 Options:
 


### PR DESCRIPTION
The `CommandHelper` already supports multiple paths - we just need to modify our code to provide them.

I'll leave a couple of additional inline comments to explain some of the changes I made.

Fixes #63 