### PR TITLE
Fixes #102: Allow DRUPAL_ROOT to be set via environmental variable.

### DIFF
--- a/src/Command/CheckCommand.php
+++ b/src/Command/CheckCommand.php
@@ -103,7 +103,12 @@ class CheckCommand extends Command
             }
         }
 
-        $drupalFinder->locateRoot($drupalRootCandidate);
+        if (getenv('DRUPAL_ROOT')) {
+            $drupalFinder->locateRoot(getenv('DRUPAL_ROOT'));
+        }
+        else {
+            $drupalFinder->locateRoot($paths[0]);
+        }
         $this->drupalRoot = $drupalFinder->getDrupalRoot();
         $this->vendorRoot = $drupalFinder->getVendorDir();
 


### PR DESCRIPTION
Enables running: `DRUPAL_ROOT=web ./vendor/bin/drupal-check web/modules/contrib/lightning_layout` and prevents a failure to find autoloader.