### PR TITLE
#156: Added an exclude option to prevent analysis in selected directories.

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,7 @@ Options:
 
 * `-a` Check analysis
 * `-d` Check deprecations (default)
+* `-e` Exclude directories. Wildcards work. Separate multiple excluded directories with commas, no spaces. e.g.: \*/tests/codeception/acceptance/\*.php
 * `--drupal-root` Path to Drupal root. Fallback option if drupal-check could not identify Drupal root from the provided path(s).
 
 Examples:
@@ -101,7 +102,7 @@ Examples:
   ```
   drupal-check -ad web/modules/contrib/address
   ```
-  
+
 ## Drupal Check - VS Code Extension
 
 You can run Drupal Check from VSCode using this extension: https://marketplace.visualstudio.com/items?itemName=bbeversdorf.drupal-check

--- a/src/Command/CheckCommand.php
+++ b/src/Command/CheckCommand.php
@@ -21,6 +21,7 @@ class CheckCommand extends Command
     private $memoryLimit;
     private $drupalRoot;
     private $vendorRoot;
+    private $excludeDirectory;
 
     protected function configure(): void
     {
@@ -34,6 +35,7 @@ class CheckCommand extends Command
             ->addOption('analysis', 'a', InputOption::VALUE_NONE, 'Check code analysis')
             ->addOption('style', 's', InputOption::VALUE_NONE, 'Check code style')
             ->addOption('memory-limit', null, InputOption::VALUE_OPTIONAL, 'Memory limit for analysis')
+            ->addOption('exclude-dir', 'e', InputOption::VALUE_OPTIONAL, 'Directories to exclude. Separate multiple directories with a comma, no spaces.')
             ->addOption(
                 'no-progress',
                 null,
@@ -48,6 +50,7 @@ class CheckCommand extends Command
         $this->isAnalysisCheck = $input->getOption('analysis');
         $this->isStyleCheck = $input->getOption('style');
         $this->memoryLimit = $input->getOption('memory-limit');
+        $this->excludeDirectory = $input->getOption('exclude-dir');
 
         if ($this->memoryLimit) {
             $output->writeln("<comment>Memory limit set to $this->memoryLimit", OutputInterface::VERBOSITY_DEBUG);
@@ -136,6 +139,12 @@ class CheckCommand extends Command
                 ]
             ]
         ];
+
+        if (!empty($this->excludeDirectory)) {
+            // There may be more than one path passed in, comma separated.
+            $excluded_directories = explode(',', $this->excludeDirectory);
+            $configuration_data['parameters']['excludes_analyse'] = array_merge($excluded_directories, $configuration_data['parameters']['excludes_analyse']);
+        }
 
         if ($this->isAnalysisCheck) {
             $configuration_data['parameters']['level'] = 4;


### PR DESCRIPTION
I added an option which lets you specify certain paths or files to exclude.

Example:
`drupal-check docroot/profiles/custom/ --exclude-dir=*/tests/codeception/acceptance/*.php`

It basically takes the option, splits it into an array (multiple values can be passed by separating them with a comma, no spaces in between), and then merges that with the array of directories and files already being excluded from analysis.

Addresses: https://github.com/mglaman/drupal-check/issues/156