### PR TITLE
190 Fix ignore all errors

### DIFF
--- a/src/Command/CheckCommand.php
+++ b/src/Command/CheckCommand.php
@@ -153,7 +153,7 @@ class CheckCommand extends Command
             $configuration_data['parameters']['level'] = 4;
 
             $ignored_analysis_errors = [
-                '#Unsafe usage of new static()#'
+                '#Unsafe usage of new static\(\)#'
             ];
             $configuration_data['parameters']['ignoreErrors'] = array_merge($ignored_analysis_errors, $configuration_data['parameters']['ignoreErrors']);
         } else {


### PR DESCRIPTION
This fixes #190 

In #136 we accidentally ignored all errors instead of just the one error:
"Unsafe usage of new static()."

This results in drupal-check failing with the following message:
```
 -- -------------------------------------------------------------------------- 
     Error                                                                     
 -- -------------------------------------------------------------------------- 
     Ignored error #Unsafe usage of new static()# has an unescaped '()' which  
     leads to ignoring all errors. Use '\(\)' instead.                         
 -- --------------------------------------------------------------------------
```