### PR TITLE
Fix #207: Allow multiple instances of drupal-check to run

### DIFF
--- a/src/Command/CheckCommand.php
+++ b/src/Command/CheckCommand.php
@@ -213,7 +213,7 @@ class CheckCommand extends Command
 
         $output->writeln(sprintf('<comment>PHPStan path: %s</comment>', $phpstanBin), OutputInterface::VERBOSITY_DEBUG);
         $configuration_encoded = Neon::encode($configuration_data, Neon::BLOCK);
-        $configuration = sys_get_temp_dir() . '/drupal_check_phpstan_' . time() . '.neon';
+        $configuration = sys_get_temp_dir() . '/drupal_check_phpstan_' . time() . '_' . getmypid() . '.neon';
         file_put_contents($configuration, $configuration_encoded);
         $configuration = realpath($configuration);
         $output->writeln(sprintf('<comment>PHPStan configuration path: %s</comment>', $configuration), OutputInterface::VERBOSITY_DEBUG);

--- a/src/Command/CheckCommand.php
+++ b/src/Command/CheckCommand.php
@@ -139,7 +139,8 @@ class CheckCommand extends Command
                 'ignoreErrors' => [],
                 'drupal' => [
                     'drupal_root' => $this->drupalRoot,
-                ]
+                ],
+                'tmpDir' => sys_get_temp_dir() . '/phpstan' . '_' . getmypid(),
             ]
         ];
 


### PR DESCRIPTION
Fixes https://github.com/mglaman/drupal-check/issues/207

Include the PHP process ID in the temporary configuration filename, so that two instances of drupal-check starting simultaneously do not share the same configuration file.