### PR TITLE
Upgrade xdebug-handler version requirement to ^2.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
     ],
     "require": {
         "php": "^7.2.5|^8.0",
-        "composer/xdebug-handler": "^1.3",
+        "composer/xdebug-handler": "^2.0.1",
         "jean85/pretty-package-versions": "^1.5.0 || ^2.0.1",
         "mglaman/phpstan-drupal": "^0.12.8",
         "nette/neon": "^3.1",

--- a/composer.lock
+++ b/composer.lock
@@ -4,20 +4,20 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "57f0b2c8e882be236d754290fadd466c",
+    "content-hash": "d4e555c28d1af2505978b665d440a017",
     "packages": [
         {
             "name": "composer/xdebug-handler",
-            "version": "1.4.6",
+            "version": "2.0.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/composer/xdebug-handler.git",
-                "reference": "f27e06cd9675801df441b3656569b328e04aa37c"
+                "reference": "964adcdd3a28bf9ed5d9ac6450064e0d71ed7496"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/composer/xdebug-handler/zipball/f27e06cd9675801df441b3656569b328e04aa37c",
-                "reference": "f27e06cd9675801df441b3656569b328e04aa37c",
+                "url": "https://api.github.com/repos/composer/xdebug-handler/zipball/964adcdd3a28bf9ed5d9ac6450064e0d71ed7496",
+                "reference": "964adcdd3a28bf9ed5d9ac6450064e0d71ed7496",
                 "shasum": ""
             },
             "require": {
@@ -52,7 +52,7 @@
             "support": {
                 "irc": "irc://irc.freenode.org/composer",
                 "issues": "https://github.com/composer/xdebug-handler/issues",
-                "source": "https://github.com/composer/xdebug-handler/tree/1.4.6"
+                "source": "https://github.com/composer/xdebug-handler/tree/2.0.1"
             },
             "funding": [
                 {
@@ -68,7 +68,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2021-03-25T17:01:18+00:00"
+            "time": "2021-05-05T19:37:51+00:00"
         },
         {
             "name": "jean85/pretty-package-versions",
@@ -1443,5 +1443,5 @@
     "platform-overrides": {
         "php": "7.2.5"
     },
-    "plugin-api-version": "2.0.0"
+    "plugin-api-version": "2.1.0"
 }

--- a/drupal-check
+++ b/drupal-check
@@ -21,7 +21,7 @@ else {
     exit(1);
 }
 
-$xdebug = new XdebugHandler('cua', '--ansi');
+$xdebug = new XdebugHandler('cua');
 $xdebug->check();
 unset($xdebug);
 


### PR DESCRIPTION
## Description
* Upgrade xdebug-handler version requirement to ^2.0.1.
* Updated [breaking change](https://github.com/composer/xdebug-handler/blob/main/UPGRADE.md).

> Break: removed optional $colorOption constructor param and passthru fallback.
> 
> Just use new XdebugHandler('myapp') to instantiate the class and color support will be detectable in the restarted process.

## Motivation
I am unable to install on a project where another dependency is requiring `composer/xdebug-handler:^2.0`.