### PR TITLE
Add an example of excluding a module to the readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,12 @@ Examples:
   drupal-check -ad web/modules/contrib/address
   ```
 
+* Check all contrib modules except the address module:
+
+  ```
+  drupal-check web/modules/contrib -e */address/*
+  ```
+
 ## Drupal Check - VS Code Extension
 
 You can run Drupal Check from VSCode using this extension: https://marketplace.visualstudio.com/items?itemName=bbeversdorf.drupal-check


### PR DESCRIPTION
Perhaps this example could help future users?

Opening because of #261 