### PR TITLE
Only display maintainers info with explicit verbosity to avoid output parsing issues

### DIFF
--- a/src/Command/CheckCommand.php
+++ b/src/Command/CheckCommand.php
@@ -262,14 +262,16 @@ class CheckCommand extends Command
 
         $output->writeln('<comment>Return PHPStan exit code</comment>', OutputInterface::VERBOSITY_DEBUG);
 
-        $output->writeln('Thanks for using <info>drupal-check</info>!');
-        $output->writeln('');
-        $output->writeln('Consider sponsoring the development of the maintainers which make <options=bold>drupal-check</> possible:');
-        $output->writeln('');
-        $output->writeln('- <options=bold>phpstan (ondrejmirtes)</>: https://github.com/sponsors/ondrejmirtes');
-        $output->writeln('- <options=bold>phpstan-deprecation-rules (ondrejmirtes))</>: https://github.com/sponsors/ondrejmirtes');
-        $output->writeln('- <options=bold>phpstan-drupal (mglaman))</>: https://github.com/sponsors/mglaman');
-        $output->writeln('- <options=bold>drupal-check (mglaman))</>: https://github.com/sponsors/mglaman');
+        if ($output->getVerbosity() === OutputInterface::VERBOSITY_VERBOSE) {
+            $output->writeln('Thanks for using <info>drupal-check</info>!');
+            $output->writeln('');
+            $output->writeln('Consider sponsoring the development of the maintainers which make <options=bold>drupal-check</> possible:');
+            $output->writeln('');
+            $output->writeln('- <options=bold>phpstan (ondrejmirtes)</>: https://github.com/sponsors/ondrejmirtes');
+            $output->writeln('- <options=bold>phpstan-deprecation-rules (ondrejmirtes))</>: https://github.com/sponsors/ondrejmirtes');
+            $output->writeln('- <options=bold>phpstan-drupal (mglaman))</>: https://github.com/sponsors/mglaman');
+            $output->writeln('- <options=bold>drupal-check (mglaman))</>: https://github.com/sponsors/mglaman');
+        }
 
         return $process->getExitCode();
     }


### PR DESCRIPTION
Maintainers message is displayed on output by default, breaking XML parsers like Jenkins.

This PR only displays the message with the -v parram

From:
```
vendor/bin/drupal-check docroot/modules/custom --format=checkstyle --no-progress'
<?xml version="1.0" encoding="UTF-8"?>
<checkstyle>
<file name="web/modules/custom/idn_celebrity_house/src/CelebrityHouseListBuilder.php">
  <error line="68" column="1" severity="error" message="Missing explicit access check on entity query." />
</file>
<file name="web/modules/custom/idn_self_promotion/src/SelfPromotionListBuilder.php">
  <error line="68" column="1" severity="error" message="Missing explicit access check on entity query." />
</file>
</checkstyle>
Thanks for using drupal-check!

Consider sponsoring the development of the maintainers which make drupal-check possible:

- phpstan (ondrejmirtes): https://github.com/sponsors/ondrejmirtes
- phpstan-deprecation-rules (ondrejmirtes)): https://github.com/sponsors/ondrejmirtes
- phpstan-drupal (mglaman)): https://github.com/sponsors/mglaman
- drupal-check (mglaman)): https://github.com/sponsors/mglaman
```

To:

```
vendor/bin/drupal-check docroot/modules/custom --format=checkstyle --no-progress'
<?xml version="1.0" encoding="UTF-8"?>
<checkstyle>
<file name="web/modules/custom/idn_celebrity_house/src/CelebrityHouseListBuilder.php">
  <error line="68" column="1" severity="error" message="Missing explicit access check on entity query." />
</file>
<file name="web/modules/custom/idn_self_promotion/src/SelfPromotionListBuilder.php">
  <error line="68" column="1" severity="error" message="Missing explicit access check on entity query." />
</file>
</checkstyle>

```