### PR TITLE
Drupal 11 compatibility

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,7 +10,7 @@ commands:
   setup-job:
     steps:
       - checkout
-      - run: sudo apt-get update && sudo apt-get install -y libpng-dev libjpeg62-turbo-dev
+      - run: sudo apt-get update && sudo apt-get install -y libpng-dev libjpeg62-dev
       - run: sudo docker-php-ext-install gd
       - run:
           name: Disable PHP memory limit

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -30,7 +30,7 @@ commands:
     parameters:
       project:
         type: string
-        default: 'drupal/recommended-project:^8.8@alpha'
+        default: 'drupal/recommended-project:^10'
       require_dev:
         type: boolean
         default: true
@@ -39,7 +39,7 @@ commands:
       - when:
           condition: << parameters.require_dev >>
           steps:
-            - run: COMPOSER_MEMORY_LIMIT=-1 composer require drupal/core-dev:^8 --dev --working-dir /tmp/drupal --no-interaction
+            - run: COMPOSER_MEMORY_LIMIT=-1 composer require drupal/core-dev:^10 --dev --working-dir /tmp/drupal --no-interaction
   require-contrib:
     parameters:
       project:
@@ -90,7 +90,7 @@ jobs:
     steps:
       - setup-job
       - create-drupal-project:
-          project: 'drupal/legacy-project:^8@alpha'
+          project: 'drupal/recommended-project:^10'
       - global-require
       - run:
           name: Global - Run against a file

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 version: 2.1
 defaults: &defaults
   docker:
-    - image: cimg/php:7.3
+    - image: cimg/php:8.2
   working_directory: ~/repo
 aliases:
   - &composer-cache

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 version: 2.1
 defaults: &defaults
   docker:
-    - image: cimg/php:8.2-cli
+    - image: cimg/php:8.2
   working_directory: ~/repo
 aliases:
   - &composer-cache

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 version: 2.1
 defaults: &defaults
   docker:
-    - image: cimg/php:8.2
+    - image: circleci/php:7.2-cli
   working_directory: ~/repo
 aliases:
   - &composer-cache
@@ -10,7 +10,14 @@ commands:
   setup-job:
     steps:
       - checkout
-      - run: sudo apt-get update && sudo apt-get install -y libpng-dev libjpeg-dev
+      - run: sudo apt-get update && sudo apt-get install -y libpng-dev libjpeg62-turbo-dev
+      - run: sudo docker-php-ext-install gd
+      - run:
+          name: Disable PHP memory limit
+          command: echo 'memory_limit=-1' | sudo tee -a /usr/local/etc/php/php.ini
+      - run:
+          name: Disable xdebug PHP extension
+          command: sudo rm /usr/local/etc/php/conf.d/docker-php-ext-xdebug.ini
       - restore_cache:
           keys:
             - *composer-cache
@@ -23,7 +30,7 @@ commands:
     parameters:
       project:
         type: string
-        default: 'drupal/recommended-project:^10'
+        default: 'drupal/recommended-project:^8.8@alpha'
       require_dev:
         type: boolean
         default: true
@@ -32,7 +39,7 @@ commands:
       - when:
           condition: << parameters.require_dev >>
           steps:
-            - run: COMPOSER_MEMORY_LIMIT=-1 composer require drupal/core-dev:^10 --dev --working-dir /tmp/drupal --no-interaction
+            - run: COMPOSER_MEMORY_LIMIT=-1 composer require drupal/core-dev:^8 --dev --working-dir /tmp/drupal --no-interaction
   require-contrib:
     parameters:
       project:
@@ -83,7 +90,7 @@ jobs:
     steps:
       - setup-job
       - create-drupal-project:
-          project: 'drupal/recommended-project:^10'
+          project: 'drupal/legacy-project:^8@alpha'
       - global-require
       - run:
           name: Global - Run against a file

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,9 +12,6 @@ commands:
       - checkout
       - run: sudo apt-get update && sudo apt-get install -y libpng-dev libjpeg-dev
       - run:
-          name: Disable PHP memory limit
-          command: echo 'memory_limit=-1' | sudo tee -a /etc/php.d/circleci.ini
-      - run:
           name: Disable xdebug PHP extension
           command: sudo rm /usr/local/etc/php/conf.d/docker-php-ext-xdebug.ini
       - restore_cache:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,7 +10,7 @@ commands:
   setup-job:
     steps:
       - checkout
-      - run: sudo apt-get update && sudo apt-get install -y libpng-dev libjpeg62-dev
+      - run: sudo apt-get update && sudo apt-get install -y libpng-dev libjpeg-dev
       - run: sudo docker-php-ext-install gd
       - run:
           name: Disable PHP memory limit

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,7 +13,7 @@ commands:
       - run: sudo apt-get update && sudo apt-get install -y libpng-dev libjpeg-dev
       - run:
           name: Disable PHP memory limit
-          command: echo 'memory_limit=-1' | sudo tee -a /usr/local/etc/php/php.ini
+          command: echo 'memory_limit=-1' | sudo tee -a /etc/php.d/circleci.ini
       - run:
           name: Disable xdebug PHP extension
           command: sudo rm /usr/local/etc/php/conf.d/docker-php-ext-xdebug.ini

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 version: 2.1
 defaults: &defaults
   docker:
-    - image: circleci/php:8.2-cli
+    - image: cimg/php:8.2-cli
   working_directory: ~/repo
 aliases:
   - &composer-cache

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 version: 2.1
 defaults: &defaults
   docker:
-    - image: cimg/php:8.2
+    - image: cimg/php:7.3
   working_directory: ~/repo
 aliases:
   - &composer-cache

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,7 +11,6 @@ commands:
     steps:
       - checkout
       - run: sudo apt-get update && sudo apt-get install -y libpng-dev libjpeg-dev
-      - run: sudo -E docker-php-ext-install gd
       - run:
           name: Disable PHP memory limit
           command: echo 'memory_limit=-1' | sudo tee -a /usr/local/etc/php/php.ini

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 version: 2.1
 defaults: &defaults
   docker:
-    - image: circleci/php:7.2-cli
+    - image: circleci/php:8.2-cli
   working_directory: ~/repo
 aliases:
   - &composer-cache

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -146,7 +146,7 @@ jobs:
       - global-require
       - create-drupal-project
       - require-contrib:
-          project: drupal/ctools:3.x-dev#d9f322857d3fd661960ee3d9dcf2c4afb773f102
+          project: drupal/ctools:3.9
       - run:
           name: Run against a module
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -146,7 +146,7 @@ jobs:
       - global-require
       - create-drupal-project
       - require-contrib:
-          project: drupal/ctools:3.x-dev
+          project: drupal/ctools:3.x-dev#d9f322857d3fd661960ee3d9dcf2c4afb773f102
       - run:
           name: Run against a module
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,7 +11,7 @@ commands:
     steps:
       - checkout
       - run: sudo apt-get update && sudo apt-get install -y libpng-dev libjpeg-dev
-      - run: sudo docker-php-ext-install gd
+      - run: sudo -E docker-php-ext-install gd
       - run:
           name: Disable PHP memory limit
           command: echo 'memory_limit=-1' | sudo tee -a /usr/local/etc/php/php.ini

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,9 +11,6 @@ commands:
     steps:
       - checkout
       - run: sudo apt-get update && sudo apt-get install -y libpng-dev libjpeg-dev
-      - run:
-          name: Disable xdebug PHP extension
-          command: sudo rm /usr/local/etc/php/conf.d/docker-php-ext-xdebug.ini
       - restore_cache:
           keys:
             - *composer-cache

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -25,6 +25,10 @@ install:
   - cd ../drupal
   - composer config --no-plugins allow-plugins.cweagans/composer-patches true
   - composer config --no-plugins allow-plugins.composer/installers true
+  - composer config --no-plugins allow-plugins.drupal/core-composer-scaffold true
+  - composer config --no-plugins dealerdirect/phpcodesniffer-composer-installer true
+  - composer config --no-plugins phpstan/extension-installer true
+  - composer config --no-plugins php-http/discovery true
   - set COMPOSER_MEMORY_LIMIT=-1&& composer install --no-interaction --ignore-platform-req=ext-gd
 build: off
 test_script:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -26,7 +26,9 @@ install:
   - composer config --no-plugins allow-plugins.cweagans/composer-patches true
   - composer config --no-plugins allow-plugins.composer/installers true
   - composer config --no-plugins allow-plugins.drupal/core-composer-scaffold true
-  - composer config --no-plugins allow-plugins.php-http/discovery true
+  - composer config --no-plugins allow-plugins.zaporylie/composer-drupal-optimizations true
+  - composer config --no-plugins allow-plugins.drupal/console-extend-plugin true
+  - composer config --no-plugins allow-plugins.dealerdirect/phpcodesniffer-composer-installer
   - set COMPOSER_MEMORY_LIMIT=-1&& composer install --no-interaction --ignore-platform-req=ext-gd
 build: off
 test_script:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -24,7 +24,7 @@ install:
   - set COMPOSER_MEMORY_LIMIT=-1&& composer create-project drupal-composer/drupal-project:8.x-dev %APPVEYOR_BUILD_FOLDER%\..\drupal --no-interaction --prefer-dist --ignore-platform-reqs --no-install
   - cd ../drupal
   - composer config --no-plugins allow-plugins.cweagans/composer-patches true
-  - set COMPOSER_MEMORY_LIMIT=-1&& composer install --ignore-platform-req=ext-gd
+  - set COMPOSER_MEMORY_LIMIT=-1&& composer install --no-interaction --ignore-platform-req=ext-gd
 build: off
 test_script:
   - php drupal-check --version

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -26,7 +26,7 @@ install:
   - composer config --no-plugins allow-plugins.cweagans/composer-patches true
   - composer config --no-plugins allow-plugins.composer/installers true
   - composer config --no-plugins allow-plugins.drupal/core-composer-scaffold true
-  - composer config --no-plugins php-http/discovery true
+  - composer config --no-plugins allow-plugins.php-http/discovery true
   - set COMPOSER_MEMORY_LIMIT=-1&& composer install --no-interaction --ignore-platform-req=ext-gd
 build: off
 test_script:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -26,7 +26,6 @@ install:
   - composer config --no-plugins allow-plugins.cweagans/composer-patches true
   - composer config --no-plugins allow-plugins.composer/installers true
   - composer config --no-plugins allow-plugins.drupal/core-composer-scaffold true
-  - composer config --no-plugins phpstan/extension-installer true
   - composer config --no-plugins php-http/discovery true
   - set COMPOSER_MEMORY_LIMIT=-1&& composer install --no-interaction --ignore-platform-req=ext-gd
 build: off

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -21,7 +21,10 @@ install:
   - refreshenv
   - SET | more
   - composer install --no-interaction --no-progress --no-suggest --prefer-dist
-  - set COMPOSER_MEMORY_LIMIT=-1&& composer create-project drupal-composer/drupal-project:8.x-dev %APPVEYOR_BUILD_FOLDER%\..\drupal --no-interaction --prefer-dist --ignore-platform-reqs
+  - set COMPOSER_MEMORY_LIMIT=-1&& composer create-project drupal-composer/drupal-project:8.x-dev %APPVEYOR_BUILD_FOLDER%\..\drupal --no-interaction --prefer-dist --ignore-platform-reqs --no-install
+  - cd drupal
+  - composer config --no-plugins allow-plugins.cweagans/composer-patches true
+  - set COMPOSER_MEMORY_LIMIT=-1&& composer install
 build: off
 test_script:
   - php drupal-check --version

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -24,6 +24,7 @@ install:
   - set COMPOSER_MEMORY_LIMIT=-1&& composer create-project drupal-composer/drupal-project:8.x-dev %APPVEYOR_BUILD_FOLDER%\..\drupal --no-interaction --prefer-dist --ignore-platform-reqs --no-install
   - cd ../drupal
   - composer config --no-plugins allow-plugins.cweagans/composer-patches true
+  - composer config --no-plugins allow-plugins.composer/installers true
   - set COMPOSER_MEMORY_LIMIT=-1&& composer install --no-interaction --ignore-platform-req=ext-gd
 build: off
 test_script:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -28,7 +28,7 @@ install:
   - composer config --no-plugins allow-plugins.drupal/core-composer-scaffold true
   - composer config --no-plugins allow-plugins.zaporylie/composer-drupal-optimizations true
   - composer config --no-plugins allow-plugins.drupal/console-extend-plugin true
-  - composer config --no-plugins allow-plugins.dealerdirect/phpcodesniffer-composer-installer
+  - composer config --no-plugins allow-plugins.dealerdirect/phpcodesniffer-composer-installer true
   - set COMPOSER_MEMORY_LIMIT=-1&& composer install --no-interaction --ignore-platform-req=ext-gd
 build: off
 test_script:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -22,7 +22,7 @@ install:
   - SET | more
   - composer install --no-interaction --no-progress --no-suggest --prefer-dist
   - set COMPOSER_MEMORY_LIMIT=-1&& composer create-project drupal-composer/drupal-project:8.x-dev %APPVEYOR_BUILD_FOLDER%\..\drupal --no-interaction --prefer-dist --ignore-platform-reqs --no-install
-  - cd drupal
+  - cd ../drupal
   - composer config --no-plugins allow-plugins.cweagans/composer-patches true
   - set COMPOSER_MEMORY_LIMIT=-1&& composer install
 build: off

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -22,7 +22,7 @@ install:
   - SET | more
   - composer install --no-interaction --no-progress --no-suggest --prefer-dist
   - set COMPOSER_MEMORY_LIMIT=-1&& composer create-project drupal-composer/drupal-project:8.x-dev %APPVEYOR_BUILD_FOLDER%\..\drupal --no-interaction --prefer-dist --ignore-platform-reqs --no-install
-  - cd ../drupal
+  - cd %APPVEYOR_BUILD_FOLDER%\..\drupal
   - composer config --no-plugins allow-plugins.cweagans/composer-patches true
   - composer config --no-plugins allow-plugins.composer/installers true
   - composer config --no-plugins allow-plugins.drupal/core-composer-scaffold true
@@ -30,6 +30,7 @@ install:
   - composer config --no-plugins allow-plugins.drupal/console-extend-plugin true
   - composer config --no-plugins allow-plugins.dealerdirect/phpcodesniffer-composer-installer true
   - set COMPOSER_MEMORY_LIMIT=-1&& composer install --no-interaction --ignore-platform-req=ext-gd
+  - cd %APPVEYOR_BUILD_FOLDER%
 build: off
 test_script:
   - php drupal-check --version

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -24,7 +24,7 @@ install:
   - set COMPOSER_MEMORY_LIMIT=-1&& composer create-project drupal-composer/drupal-project:8.x-dev %APPVEYOR_BUILD_FOLDER%\..\drupal --no-interaction --prefer-dist --ignore-platform-reqs --no-install
   - cd ../drupal
   - composer config --no-plugins allow-plugins.cweagans/composer-patches true
-  - set COMPOSER_MEMORY_LIMIT=-1&& composer install
+  - set COMPOSER_MEMORY_LIMIT=-1&& composer install --ignore-platform-req=ext-gd
 build: off
 test_script:
   - php drupal-check --version

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -26,7 +26,6 @@ install:
   - composer config --no-plugins allow-plugins.cweagans/composer-patches true
   - composer config --no-plugins allow-plugins.composer/installers true
   - composer config --no-plugins allow-plugins.drupal/core-composer-scaffold true
-  - composer config --no-plugins dealerdirect/phpcodesniffer-composer-installer true
   - composer config --no-plugins phpstan/extension-installer true
   - composer config --no-plugins php-http/discovery true
   - set COMPOSER_MEMORY_LIMIT=-1&& composer install --no-interaction --ignore-platform-req=ext-gd

--- a/composer.json
+++ b/composer.json
@@ -17,8 +17,8 @@
         "mglaman/phpstan-drupal": "^1.0.0",
         "nette/neon": "^3.1",
         "phpstan/phpstan-deprecation-rules": "^1.0.0",
-        "symfony/console": "~3.4.5 || ^4.2|| ^5.0 || ^6.0",
-        "symfony/process": "~3.4.5 || ^4.2|| ^5.0 || ^6.0",
+        "symfony/console": "~3.4.5 || ^4.2|| >=5",
+        "symfony/process": "~3.4.5 || ^4.2|| >=5",
         "webflo/drupal-finder": "^1.1"
     },
     "require-dev": {

--- a/composer.json
+++ b/composer.json
@@ -17,8 +17,8 @@
         "mglaman/phpstan-drupal": "^1.0.0",
         "nette/neon": "^3.1",
         "phpstan/phpstan-deprecation-rules": "^1.0.0",
-        "symfony/console": "~3.4.5 || ^4.2|| >=5",
-        "symfony/process": "~3.4.5 || ^4.2|| >=5",
+        "symfony/console": "~3.4.5 || ^4.2|| ^5.0 || ^6.0 || ^7.0",
+        "symfony/process": "~3.4.5 || ^4.2|| ^5.0 || ^6.0 || ^7.0",
         "webflo/drupal-finder": "^1.1"
     },
     "require-dev": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "2da033108001e4ce5752213f8d22664a",
+    "content-hash": "97b897ccfb6367d07992cecaea395ee5",
     "packages": [
         {
             "name": "composer/pcre",
@@ -1857,12 +1857,12 @@
             "version": "3.7.1",
             "source": {
                 "type": "git",
-                "url": "https://github.com/squizlabs/PHP_CodeSniffer.git",
+                "url": "https://github.com/PHPCSStandards/PHP_CodeSniffer.git",
                 "reference": "1359e176e9307e906dc3d890bcc9603ff6d90619"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/squizlabs/PHP_CodeSniffer/zipball/1359e176e9307e906dc3d890bcc9603ff6d90619",
+                "url": "https://api.github.com/repos/PHPCSStandards/PHP_CodeSniffer/zipball/1359e176e9307e906dc3d890bcc9603ff6d90619",
                 "reference": "1359e176e9307e906dc3d890bcc9603ff6d90619",
                 "shasum": ""
             },


### PR DESCRIPTION
D11 uses Symfony 7.0. Update the Symfony version constraint to also allow version 7.0 and higher.

Also
- Fixes an issue on CircleCI where it was trying to install a version of CTools that does not support D8.
- Fixes an issue on AppVeyor where Composer project creation was failing due to plugins not being allowed.